### PR TITLE
feat(registry-lint): use jv instead of ajv for clear error output

### DIFF
--- a/registry-lint/action.yaml
+++ b/registry-lint/action.yaml
@@ -43,6 +43,9 @@ runs:
           echo "packages=${{ steps.changed-packages.outputs.all_changed_files }}" >> "$GITHUB_OUTPUT"
         fi
 
+    - name: Install jv
+      uses: mason-org/actions/setup-jv@v1
+
     - name: Validate schema conformance
       if: ${{ steps.package-targets.outputs.packages != '' }}
       shell: bash

--- a/registry-lint/validate-schema.sh
+++ b/registry-lint/validate-schema.sh
@@ -6,11 +6,9 @@ fi
 
 set -euo pipefail
 
-npm install -g ajv ajv-cli ajv-formats
-
 SCHEMA_FILE=$(mktemp -t XXXX.json)
 curl -fsSL https://github.com/mason-org/registry-schema/releases/latest/download/package.schema.json > "$SCHEMA_FILE"
-<<< "$PACKAGES" tr ' ' '\n' | xargs -P10 -I{} ajv validate -d {} -c ajv-formats -s "$SCHEMA_FILE"
+<<< "$PACKAGES" tr ' ' '\n' | xargs -P10 -I{} jv -d 7 "$SCHEMA_FILE" {}
 
 for pkg in $PACKAGES; do
     # Check if CRLF characters exist in the file

--- a/setup-jv/action.yaml
+++ b/setup-jv/action.yaml
@@ -1,0 +1,18 @@
+---
+name: Setup jv
+description: Action for setting up jv(JSONSchema Validator). Only supports Linux x64.
+
+inputs:
+  version:
+    description: jv version.
+    required: false
+    default: v6.0.1
+
+runs:
+  using: composite
+  steps:
+    - name: Install jv
+      shell: bash
+      run: |
+        sudo curl -fL "https://github.com/santhosh-tekuri/jsonschema/releases/download/${{ inputs.version }}/jv-${{ inputs.version }}-linux-amd64.tar.gz" | sudo tar -C /usr/local/bin -xzf -
+        sudo chmod +x /usr/local/bin/jv


### PR DESCRIPTION
If package.yaml is not valid, registry-lint always got `error:  Unexpected identifier`, the output can be clear.

use https://github.com/santhosh-tekuri/jsonschema jv tool.

ex: invalid source type
```
$ jv -d 7 package.schema.json package.yaml
schema package.schema.json: ok

instance package.yaml: failed
jsonschema validation failed with 'file:///Users/Tom/Downloads/package.schema.json#'
- at '/source': allOf failed
  - at '/source': oneOf failed, none matched
    - at '/source/id': 'pkg:github.com/bufbuild/buf@v1.35.1' does not match pattern '^pkg:cargo/.+@.+'
    - at '/source/id': 'pkg:github.com/bufbuild/buf@v1.35.1' does not match pattern '^pkg:composer/.+/.+@.+'
    - at '/source/id': 'pkg:github.com/bufbuild/buf@v1.35.1' does not match pattern '^pkg:gem/.+@.+'
    - at '/source': oneOf failed, none matched
      - at '/source': validation failed
        - at '/source': missing property 'download'
        - at '/source/id': 'pkg:github.com/bufbuild/buf@v1.35.1' does not match pattern '^pkg:generic/.+@.+'
      - at '/source': validation failed
        - at '/source': missing property 'build'
        - at '/source/id': 'pkg:github.com/bufbuild/buf@v1.35.1' does not match pattern '^pkg:generic/.+@.+'
    - at '/source': oneOf failed, none matched
      - at '/source/id': 'pkg:github.com/bufbuild/buf@v1.35.1' does not match pattern '^pkg:github/.+/.+@.+'
      - at '/source': validation failed
        - at '/source': missing property 'build'
        - at '/source/id': 'pkg:github.com/bufbuild/buf@v1.35.1' does not match pattern '^pkg:github/.+/.+@.+'
    - at '/source/id': 'pkg:github.com/bufbuild/buf@v1.35.1' does not match pattern '^pkg:golang/.+/.+@.+'
    - at '/source/id': 'pkg:github.com/bufbuild/buf@v1.35.1' does not match pattern '^pkg:luarocks/.+@.+'
    - at '/source/id': 'pkg:github.com/bufbuild/buf@v1.35.1' does not match pattern '^pkg:npm/.+@.+'
    - at '/source/id': 'pkg:github.com/bufbuild/buf@v1.35.1' does not match pattern '^pkg:nuget/.+@.+'
    - at '/source/id': 'pkg:github.com/bufbuild/buf@v1.35.1' does not match pattern '^pkg:opam/.+@.+'
    - at '/source': validation failed
      - at '/source': missing property 'download'
      - at '/source/id': 'pkg:github.com/bufbuild/buf@v1.35.1' does not match pattern '^pkg:openvsx/.+/.+@.+'
    - at '/source/id': 'pkg:github.com/bufbuild/buf@v1.35.1' does not match pattern '^pkg:pypi/.+@.+'
```