### PR TITLE
chore(tests): upgrade OTP version to 27 and Elixir to 1.17

### DIFF
--- a/tests/action.yaml
+++ b/tests/action.yaml
@@ -26,8 +26,8 @@ runs:
     - if: ${{ steps.prepare.outputs.setup_beam == 'true' }}
       uses: erlef/setup-beam@v1
       with:
-        otp-version: '24'
-        elixir-version: '1.14'
+        otp-version: '27'
+        elixir-version: '1.17'
         rebar3-version: '3'
 
     - if: ${{ steps.prepare.outputs.setup_nix == 'true' }}


### PR DESCRIPTION
During the automated upgrade of the erlang-ls version, the GitHub Action encountered an issue:
[See the action run with the error](https://github.com/mason-org/mason-registry/actions/runs/11257092069/job/31300545453?pr=7405).

I believe the issue might be related to the one discussed here:
[erlware/relx#941](https://github.com/erlware/relx/pull/941).

Since macOS uses Homebrew for installation, it always pulls the latest version of the required tools. To address the compatibility issue, I upgraded the OTP and Elixir versions for the Linux and Windows environments to ensure consistent builds across all platforms.

Let me know if any further adjustments are needed!  😊 @williamboman 