### PR TITLE
Install lua for fnlfmt package builds

### DIFF
--- a/tests/prepare.sh
+++ b/tests/prepare.sh
@@ -176,7 +176,7 @@ match install-erlang "packages/erlang-ls/package.yaml" "packages/erlang-debugger
 match install-ghc "packages/haskell-language-server/package.yaml" "packages/haskell-debug-adapter/package.yaml"
 match install-golang "pkg:golang"
 match install-java "packages/java-language-server/package.yaml"
-match install-luarocks "pkg:luarocks"
+match install-luarocks "pkg:luarocks" "packages/fnlfmt/package.yaml"
 match install-nim "packages/nimlsp/package.yaml" "packages/nimlangserver/package.yaml"
 match install-nix "packages/nil/package.yaml"
 match install-opam "pkg:opam"


### PR DESCRIPTION
https://github.com/mason-org/mason-registry/pull/10202 needs lua to be installed to build fnlfmt (unfortunately it's not on luarocks)

Alternative to this would be to have a `match install-lua` specific which I can do if it makes sense. Technically this is only using the `install-luarocks` functionality that triggers the lua GH actions, not the actual luarocks action. 🤷