### PR TITLE
refactor(tests): use vim.fs instead of vim.fn.fnamemodify

### DIFF
--- a/tests/action.yaml
+++ b/tests/action.yaml
@@ -103,7 +103,7 @@ runs:
       uses: rhysd/action-setup-vim@v1
       with:
         neovim: true
-        # Minimum supported mason.nvim version
+        # Minimum version supported by mason.nvim
         version: v0.10.0
 
     - if: ${{ steps.prepare.outputs.PACKAGES != '' }}

--- a/tests/test-runner.lua
+++ b/tests/test-runner.lua
@@ -125,7 +125,7 @@ local ok, err = pcall(a.run_blocking, function()
 
         for __, pkg_path in ipairs(packages) do
             -- Turns "packages/rust-analyzer/package.yaml" into "rust-analyzer"
-            local pkg_name = vim.fn.fnamemodify(pkg_path, ":h:t")
+            local pkg_name = vim.fs.basename(vim.fs.dirname(pkg_path))
             local pkg = registry.get_package(pkg_name)
             a.scheduler()
             get_targets(pkg)


### PR DESCRIPTION
While it's probably safe to call vim.fn here, we want to avoid doing so as much as possible because this can only be
done when executing in the main event loop. mason.nvim, and its user callbacks, executes a large chunk of its code
outside of the main event loop due to frequent async interactions with libuv.

Oh, also better readability :P
