### PR TITLE
Groovy Language Server requires a recent Java version

### DIFF
--- a/tests/prepare.sh
+++ b/tests/prepare.sh
@@ -175,7 +175,7 @@ fi
 match install-erlang "packages/erlang-ls/package.yaml" "packages/erlang-debugger/package.yaml"
 match install-ghc "packages/haskell-language-server/package.yaml" "packages/haskell-debug-adapter/package.yaml"
 match install-golang "pkg:golang"
-match install-java "packages/java-language-server/package.yaml"
+match install-java "packages/java-language-server/package.yaml" "packages/groovy-language-server/package.yaml"
 match install-luarocks "pkg:luarocks" "packages/fnlfmt/package.yaml"
 match install-nim "packages/nimlsp/package.yaml" "packages/nimlangserver/package.yaml"
 match install-nix "packages/nil/package.yaml"


### PR DESCRIPTION
Groovy Language Server updated the Gradle version which now requires Java 17 or newer.

This should fix the https://github.com/mason-org/mason-registry/pull/11843