### PR TITLE
feat(tests): enable firewall in mason

### DIFF
--- a/tests/test-runner.lua
+++ b/tests/test-runner.lua
@@ -44,6 +44,9 @@ require("mason").setup {
     log_level = vim.log.levels[DEBUG and "DEBUG" or "INFO"],
     registries = {
         "file:" .. vim.env.REGISTRY
+    },
+    firewall = {
+        enabled = true
     }
 }
 registry.refresh()


### PR DESCRIPTION
This will enable the firewall feature in mason.nvim in our CI test suite.

@mason-org/triage This might/will result in package tests failing for a new reason, the logs should be clear as to what the firewall is blocking.